### PR TITLE
github issue api를 context api로 랩핑하여 전역으로 관리하게끔 구현합니다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 .eslintcache
 eslint-result.html
+
+.env*
+!.env.sample

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,17 +6,20 @@ import IssueList from '@/pages/IssueList/IssueList';
 import IssueDetail from '@/pages/IssueDetail/IssueDetail';
 import { ROUTES } from '@/constants/route';
 import IssuesProvider from '@/context/IssuesProvider';
+import IssueDetailsProvider from './context/IssueDetailsProvider';
 
 const App = () => (
   <>
     <Global styles={resetCss} />
 
     <IssuesProvider>
-      <Routes>
-        <Route path={ROUTES.HOME} element={<Home />} />
-        <Route path={ROUTES.ISSUE_LIST} element={<IssueList />} />
-        <Route path={`${ROUTES.ISSUE_DETAIL}/:issueId`} element={<IssueDetail />} />
-      </Routes>
+      <IssueDetailsProvider>
+        <Routes>
+          <Route path={ROUTES.HOME} element={<Home />} />
+          <Route path={ROUTES.ISSUE_LIST} element={<IssueList />} />
+          <Route path={`${ROUTES.ISSUE_DETAIL}/:issueId`} element={<IssueDetail />} />
+        </Routes>
+      </IssueDetailsProvider>
     </IssuesProvider>
   </>
 );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,16 +5,20 @@ import Home from '@/pages/Home/Home';
 import IssueList from '@/pages/IssueList/IssueList';
 import IssueDetail from '@/pages/IssueDetail/IssueDetail';
 import { ROUTES } from '@/constants/route';
+import IssuesProvider from '@/context/IssuesProvider';
 
 const App = () => (
-  <div>
+  <>
     <Global styles={resetCss} />
-    <Routes>
-      <Route path={ROUTES.HOME} element={<Home />} />
-      <Route path={ROUTES.ISSUE_LIST} element={<IssueList />} />
-      <Route path={`${ROUTES.ISSUE_DETAIL}/:issueId`} element={<IssueDetail />} />
-    </Routes>
-  </div>
+
+    <IssuesProvider>
+      <Routes>
+        <Route path={ROUTES.HOME} element={<Home />} />
+        <Route path={ROUTES.ISSUE_LIST} element={<IssueList />} />
+        <Route path={`${ROUTES.ISSUE_DETAIL}/:issueId`} element={<IssueDetail />} />
+      </Routes>
+    </IssuesProvider>
+  </>
 );
 
 export default App;

--- a/src/context/IssueDetailsProvider.jsx
+++ b/src/context/IssueDetailsProvider.jsx
@@ -1,0 +1,37 @@
+import { createContext, useMemo, useState } from 'react';
+import issueApiService from '@/api/issue';
+
+export const IssueDetailsStoreContext = createContext(null);
+export const IssueDetailsActionsContext = createContext(null);
+
+const IssueDetailsProvider = ({ children }) => {
+  const [issueDetails, setIssueDetails] = useState([]);
+
+  const actions = useMemo(
+    () => ({
+      async fetchIssueDetail({ issueNumber } = {}) {
+        try {
+          const issueDetailResponse = await issueApiService.getIssueDetail({
+            owner: 'angular',
+            repo: 'angular-cli',
+            issue_number: issueNumber,
+          });
+          setIssueDetails(prevIssueDetails => [...prevIssueDetails, issueDetailResponse]);
+        } catch (error) {
+          throw new Error(error);
+        }
+      },
+    }),
+    []
+  );
+
+  return (
+    <IssueDetailsActionsContext.Provider value={actions}>
+      <IssueDetailsStoreContext.Provider value={issueDetails}>
+        {children}
+      </IssueDetailsStoreContext.Provider>
+    </IssueDetailsActionsContext.Provider>
+  );
+};
+
+export default IssueDetailsProvider;

--- a/src/context/IssuesProvider.jsx
+++ b/src/context/IssuesProvider.jsx
@@ -1,0 +1,39 @@
+import { createContext, useMemo, useRef, useState } from 'react';
+import issueApiService from '@/api/issue';
+
+export const IssuesStoreContext = createContext(null);
+export const IssuesActionsContext = createContext(null);
+
+const IssuesProvider = ({ children }) => {
+  const [issues, setIssues] = useState([]);
+  const pageRef = useRef(1);
+
+  const actions = useMemo(() => {
+    return {
+      async fetchIssues() {
+        const page = pageRef.current;
+
+        try {
+          const issuesResponse = await issueApiService.getIssues({
+            owner: 'angular',
+            repo: 'angular-cli',
+            sort: 'comments',
+            page,
+          });
+          setIssues(prevIssues => [...prevIssues, ...issuesResponse]);
+          pageRef.current += 1;
+        } catch (error) {
+          throw new Error(error);
+        }
+      },
+    };
+  }, []);
+
+  return (
+    <IssuesActionsContext.Provider value={actions}>
+      <IssuesStoreContext.Provider value={issues}>{children}</IssuesStoreContext.Provider>
+    </IssuesActionsContext.Provider>
+  );
+};
+
+export default IssuesProvider;

--- a/src/hooks/useIssueDetailActions.js
+++ b/src/hooks/useIssueDetailActions.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { IssueDetailsActionsContext } from '@/context/IssueDetailsProvider';
+
+const useIssueDetailsActions = () => {
+  const actions = useContext(IssueDetailsActionsContext);
+  if (actions === null) {
+    throw new Error('useIssuesActions should be used within IssueDetailsProvider');
+  }
+  return actions;
+};
+
+export default useIssueDetailsActions;

--- a/src/hooks/useIssueDetailStore.js
+++ b/src/hooks/useIssueDetailStore.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { IssueDetailsStoreContext } from '@/context/IssueDetailsProvider';
+
+const useIssueDetailsStore = () => {
+  const issueDetails = useContext(IssueDetailsStoreContext);
+  if (issueDetails === null) {
+    throw new Error('useIssueDetailsStore should be used within IssueDetailsProvider');
+  }
+  return issueDetails;
+};
+
+export default useIssueDetailsStore;

--- a/src/hooks/useIssuesActions.js
+++ b/src/hooks/useIssuesActions.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { IssuesActionsContext } from '@/context/IssuesProvider';
+
+const useIssuesActions = () => {
+  const actions = useContext(IssuesActionsContext);
+  if (actions === null) {
+    throw new Error('useIssuesActions should be used within IssuesProvider');
+  }
+  return actions;
+};
+
+export default useIssuesActions;

--- a/src/hooks/useIssuesStore.js
+++ b/src/hooks/useIssuesStore.js
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { IssuesStoreContext } from '@/context/IssuesProvider';
+
+const useIssuesStore = () => {
+  const issues = useContext(IssuesStoreContext);
+  if (issues === null) {
+    throw new Error('useIssuesStore should be used within IssuesProvider');
+  }
+  return issues;
+};
+
+export default useIssuesStore;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,9 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from '@/App';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
 );


### PR DESCRIPTION
## 변경사항

- issue 리스트 데이터를 context API를 통해 전역적으로 관리하는 패턴으로 구현하였습니다.
- 개발과정 중 useEffect의 중복호출 현상이 있어 이를 방지하기 위해 main.jsx에 React.StrictMode 컴포넌트를 제거해주었습니다.
- .env 파일을 gitignore목록에 추가해주었습니다.
- useContext를 직접 호출하기 보단 커스텀 훅으로 한번 랩핑하여 Provider 외부에서 쓸 경우에 대한 예외처리 및 hook에 명시적인 이름을 붙혀줌으로써 사용성, 가독성에 한번 더 신경 써주었습니다.

커스텀 훅의 간단 사용법은 다음과 같습니다.
```jsx
// 이슈 리스트
const Home = () => {
  const { fetchIssues } = useIssuesActions();
  const issues = useIssuesStore();

  useEffect(() => {
    fetchIssues();
  }, [fetchIssues]);

  return (
    <ul>
      {issues.map(({ title, number }) => (
        <li key={number}>{title}</li>
      ))}
    </ul>
  );
};
```

```jsx
// 이슈 상세
const IssueDetail = () => {
  const { issueId } = useParams();

  const issueDetails = useIssueDetailsStore();
  const { fetchIssueDetail } = useIssueDetailsActions();

  const currentIssueDetail = issueDetails.find(({ number }) => {
    return number === +issueId;
  });

  useEffect(() => {
    if (currentIssueDetail) return;

    fetchIssueDetail({ issueNumber: issueId });
  }, [currentIssueDetail, fetchIssueDetail, issueId]);

  if (!currentIssueDetail) return <Loading />;

  return <Layout>{currentIssueDetail.title}</Layout>;
};
```

contextAPI 사용 패턴은 다음 레퍼런스를 참고하였습니다.
[다른 사람들이 안 알려주는 리액트에서 Context API 잘 쓰는 방법](https://velog.io/@velopert/react-context-tutorial#%EA%B0%92%EA%B3%BC-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-%ED%95%A8%EC%88%98%EB%A5%BC-%EB%91%90%EA%B0%9C%EC%9D%98-context%EB%A1%9C-%EB%B6%84%EB%A6%AC%ED%95%98%EA%B8%B0)

